### PR TITLE
fixed 2 issues

### DIFF
--- a/MacSymbolicator/AppDelegate.m
+++ b/MacSymbolicator/AppDelegate.m
@@ -99,13 +99,17 @@
 }
 
 - (NSString*)searchArchivesFolderByDSYMLookingForUUID:(NSString*)uuid {
-    NSString* allDSYMs = [@"find ~/Library/Developer/Xcode/Archives/ -name *.dSYM" runAsCommand];
-    NSArray* dsymFiles = [allDSYMs componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
-    
-    if ([[dsymFiles firstObject] hasPrefix:@"find:"]) {  // `find` error
-        return nil;
-    }
-    
+	
+	NSURL* archivesURL = [NSURL fileURLWithPath:[NSHomeDirectory() stringByAppendingPathComponent:@"/Library/Developer/Xcode/Archives"]];
+	NSDirectoryEnumerator<NSURL *> *urlEnumerator = [[NSFileManager defaultManager] enumeratorAtURL:archivesURL includingPropertiesForKeys:nil options:NSDirectoryEnumerationSkipsHiddenFiles errorHandler:nil];
+	
+	NSMutableArray* dsymFiles = [[NSMutableArray alloc] init];
+	for(NSURL* url in urlEnumerator) {
+		if ([url.lastPathComponent.pathExtension isEqualToString:@"dSYM"]) {
+			[dsymFiles addObject:url.path];
+		}
+	}
+
     return [self getFileForUUID:uuid inList:dsymFiles];
 }
 

--- a/MacSymbolicator/AppDelegate.m
+++ b/MacSymbolicator/AppDelegate.m
@@ -129,30 +129,33 @@
 }
 
 - (void)startSearchForDSYM {
+	
+	[_dSYMDropZone setDetailText:@"Searching…"];
+	
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        
-        [_dSYMDropZone setDetailText:@"Searching…"];
-        
+		
         NSString* uuidLookedFor = [_crashReport uuid];
+		NSLog(@"searching for crash UUID: %@", uuidLookedFor);
         
         NSString* file = [self searchSpotlightByUUIDLookingFor:uuidLookedFor];
         if (!file) file = [self searchSpotlightByDSYMLookingForUUID:uuidLookedFor];
         if (!file) file = [self searchArchivesFolderByDSYMLookingForUUID:uuidLookedFor];
-        
-        if (file) {
-            [_dSYMDropZone setFile:file];
-            [_dSYMDropZone setDetailText:file];
-            DSYMFile* f = [DSYMFile dsymWithFile:file];
-            [self setDsymFile:f];
-            
-            [_differentUUIDLabel setHidden:[_crashReport.uuid isEqualToString:_dsymFile.uuid]];
-        } else {
-            [_dSYMDropZone setDetailText:@""];
-        }
-        
+		
         dispatch_async(dispatch_get_main_queue(), ^{
-            
-            [self symbolicate:nil];
+			
+			if (file) {
+				[_dSYMDropZone setFile:file];
+				[_dSYMDropZone setDetailText:file];
+				DSYMFile* f = [DSYMFile dsymWithFile:file];
+				[self setDsymFile:f];
+				
+				[_differentUUIDLabel setHidden:[_crashReport.uuid isEqualToString:_dsymFile.uuid]];
+				
+				[self symbolicate:nil];
+			} else {
+				[_dSYMDropZone setDetailText:@""];
+			}
+			
             
             if (![_resultWindow isKeyWindow]) { // if symbolication failed / dsym not found
                 [_window makeKeyAndOrderFront:nil];


### PR DESCRIPTION
Hi,

I fixed two issues that prevented my from symbolicating crash logs on my Mojave machine.

1) user interface should only be updated on the main thread, not a big deal but fixed it anyway.
2) the find command never returned any bytes, even though it did when invoking the command in Terminal. Fixed that by replacing the relevant code with a directory enumerator.

Cheers,
Martin