### PR TITLE
Use extended string delimiters on regex literals to make them more readable

### DIFF
--- a/MacSymbolicator/DSYM Search/FileSearch.swift
+++ b/MacSymbolicator/DSYM Search/FileSearch.swift
@@ -93,7 +93,7 @@ private class InternalFileSearch: FileSearchResults, FileSearchQuery {
 
             guard let dwarfDumpOutput = commandResult.output?.trimmed else { return nil }
 
-            let foundUUIDs = dwarfDumpOutput.scan(pattern: "UUID: (.*) \\(").flatMap({ $0 })
+            let foundUUIDs = dwarfDumpOutput.scan(pattern: #"UUID: (.*) \("#).flatMap({ $0 })
             for foundUUID in foundUUIDs {
                 if uuids.contains(foundUUID) {
                     return FileSearchResult(path: file, matchedUUID: foundUUID)

--- a/MacSymbolicator/Models/BinaryImage.swift
+++ b/MacSymbolicator/Models/BinaryImage.swift
@@ -9,8 +9,8 @@ struct BinaryImage {
     let uuid: BinaryUUID
     let loadAddress: String
 
-    private static let binaryImagesSectionRegex = "Binary Images:.*"
-    private static let binaryImagesLineRegex = "(0x.*?)\\s.*?<(.*?)>"
+    private static let binaryImagesSectionRegex = #"Binary Images:.*"#
+    private static let binaryImagesLineRegex = #"(0x.*?)\s.*?<(.*?)>"#
 
     static func find(in content: String) -> [BinaryImage] {
         let binaryImagesSection = content.scan(

--- a/MacSymbolicator/Models/CrashFile.swift
+++ b/MacSymbolicator/Models/CrashFile.swift
@@ -51,13 +51,13 @@ public class CrashFile {
         self.path = path
         self.filename = path.lastPathComponent
 
-        self.architecture = content.scan(pattern: "^Code Type:(.*?)(\\(.*\\))?$").first?.first?.trimmed
+        self.architecture = content.scan(pattern: #"^Code Type:(.*?)(\(.*\))?$"#).first?.first?.trimmed
             .components(separatedBy: " ").first.flatMap(Architecture.init)
 
         // In the case of "ARM" the actual architecture is on the first line of Binary Images
         if self.architecture?.isIncomplete == true {
             self.architecture = (content.scan(
-                pattern: "Binary Images:.*\\s+([^\\s]+)\\s+<",
+                pattern: #"Binary Images:.*\s+([^\s]+)\s+<"#,
                 options: [.caseInsensitive, .anchorsMatchLines, .dotMatchesLineSeparators]
             ).first?.first?.trimmed).flatMap(Architecture.init)
         }

--- a/MacSymbolicator/Models/DSYMFile.swift
+++ b/MacSymbolicator/Models/DSYMFile.swift
@@ -51,7 +51,7 @@ public struct DSYMFile: Equatable {
 
         output?.components(separatedBy: .newlines).forEach { line in
             guard
-                let match = line.scan(pattern: "UUID: (.*) \\((.*)\\)").first, match.count == 2,
+                let match = line.scan(pattern: #"UUID: (.*) \((.*)\)"#).first, match.count == 2,
                 let uuid = match.first.flatMap(BinaryUUID.init),
                 let architecture = match.last.flatMap(Architecture.init)
             else { return }

--- a/MacSymbolicator/Models/StackTraceCall.swift
+++ b/MacSymbolicator/Models/StackTraceCall.swift
@@ -9,18 +9,18 @@ struct StackTraceCall {
     let address: String
     let loadAddress: String
 
-    private static let crashLineRegex = "^\\d+\\s+.*?0x.*?\\s0x.*?\\s"
-    private static let crashAddressRegex = "^\\d+\\s+.*?(0x.*?)\\s(0x.*?)\\s"
+    private static let crashLineRegex = #"^\d+\s+.*?0x.*?\s0x.*?\s"#
+    private static let crashAddressRegex = #"^\d+\s+.*?(0x.*?)\s(0x.*?)\s"#
 
     static func crashReplacementRegex(address: String) -> String {
-        "\(address)\\s0x.*?$"
+        #"\#(address)\s0x.*?$"#
     }
 
-    private static let sampleLineRegex = "\\?{3}\\s+\\(in\\s.*?\\)\\s+load\\saddress.*?\\[0x.*?\\]"
-    private static let sampleAddressRegex = "\\?{3}\\s+\\(in\\s.*?\\)\\s+load\\saddress\\s*(0x.*?)\\s.*?\\[(0x.*?)\\]"
+    private static let sampleLineRegex = #"\?{3}\s+\(in\s.*?\)\s+load\saddress.*?\[0x.*?\]"#
+    private static let sampleAddressRegex = #"\?{3}\s+\(in\s.*?\)\s+load\saddress\s*(0x.*?)\s.*?\[(0x.*?)\]"#
 
     static func sampleReplacementRegex(address: String) -> String {
-        "\\?{3}.*?\\[\(address)\\]"
+      #"\?{3}.*?\[\#(address)\]"#
     }
 
     static func find(in content: String) -> [StackTraceCall] {


### PR DESCRIPTION
Swift 5 features [Extended String Delimiters](https://docs.swift.org/swift-book/LanguageGuide/StringsAndCharacters.html#ID606) which is especially useful for expressing regular expressions.

This PR switches all regex literals to extended string delimiters, making them more readable.