### PR TITLE
Fix: Unable to load dSYM Files with parentheses in path

### DIFF
--- a/MacSymbolicator/Models/DSYMFile.swift
+++ b/MacSymbolicator/Models/DSYMFile.swift
@@ -51,7 +51,7 @@ public struct DSYMFile: Equatable {
 
         output?.components(separatedBy: .newlines).forEach { line in
             guard
-                let match = line.scan(pattern: #"UUID: (.*) \((.*)\)"#).first, match.count == 2,
+                let match = line.scan(pattern: #"UUID: (.*?) \((.*?)\)"#).first, match.count == 2,
                 let uuid = match.first.flatMap(BinaryUUID.init),
                 let architecture = match.last.flatMap(Architecture.init)
             else { return }


### PR DESCRIPTION
When the dSYM has a parentheses in the path, the line looks like this:
> UUID: A11B11CD-6788-3244-BF17-545FFBAA3AFB (x86_64) /Users/neil/Documents/Xcode Archives/2022-11-24/TestApp (macOS) 11-24-22, 8.17 PM.xcarchive/dSYMs/TestApp.app.dSYM/Contents/Resources/DWARF/TestApp

In this case, the regex to pull out the UUID and Architecture matches greedily and extracts the wrong values.

Per [NSRegularExpression's Documentation – Table 2](https://developer.apple.com/documentation/foundation/nsregularexpression#1965590), switch from `*` (Match 0 or more times. Match as many times as possible)  to `*?` (Match 0 or more times. Match as few times as possible).