### PR TITLE
DSYM FileSearch.matching() semantically requires "for where"

### DIFF
--- a/MacSymbolicator/DSYM Search/FileSearch.swift
+++ b/MacSymbolicator/DSYM Search/FileSearch.swift
@@ -94,10 +94,8 @@ private class InternalFileSearch: FileSearchResults, FileSearchQuery {
             guard let dwarfDumpOutput = commandResult.output?.trimmed else { return nil }
 
             let foundUUIDs = dwarfDumpOutput.scan(pattern: #"UUID: (.*) \("#).flatMap({ $0 })
-            for foundUUID in foundUUIDs {
-                if uuids.contains(foundUUID) {
-                    return FileSearchResult(path: file, matchedUUID: foundUUID)
-                }
+            for foundUUID in foundUUIDs where uuids.contains(foundUUID) {
+                return FileSearchResult(path: file, matchedUUID: foundUUID)
             }
 
             return nil


### PR DESCRIPTION
  - `for` loop used to locate a DSYM that matches a given UUID fails to locate the DSYM unless `where` is used instead of an embedded `if` statement