### PR TITLE
Add CLI option to list the necessary image UUIDs

### DIFF
--- a/MacSymbolicator/Models/BinaryImage.swift
+++ b/MacSymbolicator/Models/BinaryImage.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-struct BinaryImage: Equatable {
+struct BinaryImage: Equatable, Hashable {
     let name: String
     let uuid: BinaryUUID
     let loadAddress: String

--- a/MacSymbolicator/Models/ReportProcess.swift
+++ b/MacSymbolicator/Models/ReportProcess.swift
@@ -14,6 +14,11 @@ public class ReportProcess {
     private static let processSectionRegex = #"^(Process:.*?)(?=\z|^Process:)"#
     private static let processNameRegex = #"^Process:\s*(.+?)\s*\["#
 
+    lazy var binariesForSymbolication: [BinaryImage] = {
+        let uuids = frames.map { $0.binaryImage }
+        return Array(Set<BinaryImage>(uuids))
+    }()
+    
     lazy var uuidsForSymbolication: [BinaryUUID] = {
         let uuids = frames.map { $0.binaryImage.uuid }
         return Array(Set<BinaryUUID>(uuids))

--- a/MacSymbolicatorCLI/CLI.swift
+++ b/MacSymbolicatorCLI/CLI.swift
@@ -51,7 +51,7 @@ struct MacSymbolicatorCLI: ParsableCommand {
         
         if uuidsOnly {
             let dsymIdents = reportFile.processes.map {
-                $0.binaryImages.map { "\($0.name)/\($0.uuid.pretty)"}.joined(separator: "\n")
+                $0.binariesForSymbolication.map { "\($0.name)/\($0.uuid.pretty)"}.joined(separator: "\n")
             }.joined(separator: "\n")
             
             if let output = output {

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Supports symbolicating:
 Includes a command-line interface (`MacSymbolicator.app/Contents/MacOS/MacSymbolicatorCLI`):
 
 ```
-USAGE: mac-symbolicator-cli [--translate-only] [--verbose] [--output <output>] <report-file-path> [<dsym-path> ...]
+USAGE: mac-symbolicator-cli [--translate-only] [--uuids-only] [--verbose] [--output <output>] <report-file-path> [<dsym-path> ...]
 
 ARGUMENTS:
   <report-file-path>      The report file: .crash/.ips for crash reports .txt for samples/spindumps
@@ -20,6 +20,7 @@ ARGUMENTS:
 
 OPTIONS:
   -t, --translate-only    Translate the crash report from .ips to .crash
+  -u, --uuids-only        Output binary images and UUIDs
   -v, --verbose
   -o, --output <output>   The output file to save the result to, instead of printing to stdout
   -h, --help              Show help information.


### PR DESCRIPTION
A script using the CLI will generally need the image names and UUIDs so it can locate the dsym bundle(s) it needs to pass to the CLI.

This adds a --uuids-only switch that dumps out the list of binary image names and their UUIDs for a calling script to use.

The output is formatted `image_name/CC917C9F-8992-439F-9290-2A1965BEF989`

Fixes issue #38 