### PR TITLE
Add support for ".hang" files

### DIFF
--- a/MacSymbolicator/Controllers/InputCoordinator.swift
+++ b/MacSymbolicator/Controllers/InputCoordinator.swift
@@ -7,9 +7,9 @@ import Foundation
 
 class InputCoordinator {
     let reportFileDropZone = DropZone(
-        fileTypes: [".crash", ".ips", ".txt"],
+        fileTypes: [".crash", ".ips", ".txt", ".hang"],
         allowsMultipleFiles: false,
-        text: "Drop Report File\n(crash, sample, or spindump)",
+        text: "Drop Report File\n(crash, sample, spindump or hang)",
         activatesAppAfterDrop: true
     )
 

--- a/MacSymbolicator/Models/ReportFile.swift
+++ b/MacSymbolicator/Models/ReportFile.swift
@@ -16,9 +16,15 @@ public class ReportFile {
     let path: URL
     let filename: String
     let processes: [ReportProcess]
+    
+    lazy var binariesForSymbolication: [BinaryImage] = {
+        let images = processes.flatMap { $0.binariesForSymbolication }
+        return Array(Set<BinaryImage>(images))
+    }()
 
     lazy var uuidsForSymbolication: [BinaryUUID] = {
-        processes.flatMap { $0.uuidsForSymbolication }
+        let uuids = processes.flatMap { $0.uuidsForSymbolication }
+        return Array(Set<BinaryUUID>(uuids))
     }()
 
     let content: String

--- a/MacSymbolicator/Models/ReportFile.swift
+++ b/MacSymbolicator/Models/ReportFile.swift
@@ -40,7 +40,7 @@ public class ReportFile {
             .appendingPathExtension(originalPathExtension)
     }
 
-    public init(path: URL) throws {
+    public init(path: URL, targetProcessName: String? = nil) throws {
         let originalContent: String
 
         do {
@@ -53,7 +53,7 @@ public class ReportFile {
             throw InitializationError.emptyFile
         }
 
-        var processes = ReportProcess.find(in: originalContent)
+        var processes = ReportProcess.find(in: originalContent, targetProcess: targetProcessName)
 
         if processes.isEmpty && originalContent.hasPrefix("{") {
             // Could not find any processes defined in the report file -> Probably not the usual crash report format
@@ -70,7 +70,7 @@ public class ReportFile {
                 }
             }
 
-            processes = ReportProcess.find(in: content)
+            processes = ReportProcess.find(in: content, targetProcess: targetProcessName)
         } else {
             self.content = originalContent
         }

--- a/MacSymbolicator/Models/ReportProcess.swift
+++ b/MacSymbolicator/Models/ReportProcess.swift
@@ -24,7 +24,7 @@ public class ReportProcess {
         return Array(Set<BinaryUUID>(uuids))
     }()
 
-    static func find(in content: String) -> [ReportProcess] {
+    static func find(in content: String, targetProcess: String?) -> [ReportProcess] {
         let processSections = content.scan(
             pattern: processSectionRegex,
             options: [.caseInsensitive, .anchorsMatchLines, .dotMatchesLineSeparators]
@@ -32,12 +32,20 @@ public class ReportProcess {
 
         return processSections.compactMap {
             guard let match = $0.first else { return nil }
-            return ReportProcess(parsing: match)
+            return ReportProcess(parsing: match, targetProcess: targetProcess)
         }
     }
 
-    init?(parsing content: String) {
+    init?(parsing content: String, targetProcess: String?) {
         name = content.scan(pattern: Self.processNameRegex).first?.first
+        if (name == nil) {
+            return nil;
+        }
+        if (!(targetProcess ?? "").isEmpty) {
+            if (!name!.contains(targetProcess!)) {
+                return nil;
+            }
+        }
         architecture = Architecture.find(in: content)
         binaryImages = BinaryImage.find(in: content)
         frames = StackFrame.find(

--- a/MacSymbolicatorCLI/CLI.swift
+++ b/MacSymbolicatorCLI/CLI.swift
@@ -21,10 +21,13 @@ struct MacSymbolicatorCLI: ParsableCommand {
     @Flag(name: .shortAndLong)
     var verbose = false
 
+    @Option(name: .shortAndLong, help: "Only symbolicate process names containing this substring (case sensitive). Useful with HANG files as these contain many processes.")
+    var processName: String?
+
     @Option(name: .shortAndLong, help: "The output file to save the result to, instead of printing to stdout")
     var output: String?
 
-    @Argument(help: "The report file: .crash/.ips for crash reports .txt for samples/spindumps")
+    @Argument(help: "The report file: .crash/.ips for crash reports .txt/.hang for samples/spindumps/hangs")
     var reportFilePath: String
 
     @Argument(help: "The dSYMs to use for symbolication")
@@ -37,7 +40,7 @@ struct MacSymbolicatorCLI: ParsableCommand {
             )
         }
 
-        let reportFile = try ReportFile(path: URL(fileURLWithPath: reportFilePath))
+        let reportFile = try ReportFile(path: URL(fileURLWithPath: reportFilePath), targetProcessName: processName)
 
         if translateOnly {
             try translateReport(reportFile)

--- a/MacSymbolicatorCLI/CLI.swift
+++ b/MacSymbolicatorCLI/CLI.swift
@@ -113,8 +113,7 @@ struct MacSymbolicatorCLI: ParsableCommand {
     }
 
     private func printUUIDsForReport(_ reportFile: ReportFile) throws {
-        let dsymIdents = reportFile.processes.map {
-            $0.binariesForSymbolication.map { "\($0.name)/\($0.uuid.pretty)"}.joined(separator: "\n")
+        let dsymIdents = reportFile.binariesForSymbolication.map { "\($0.name)/\($0.uuid.pretty)"
         }.joined(separator: "\n")
 
         if let output = output {

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ OPTIONS:
   -t, --translate-only    Translate the crash report from .ips to .crash
   -u, --uuids-only        Output binary images and UUIDs
   -v, --verbose
+  -p, --process-name <process-name>
+                          Only symbolicate process names containing this substring (case
+                          sensitive). Useful with HANG files as these contain many processes.
   -o, --output <output>   The output file to save the result to, instead of printing to stdout
   -h, --help              Show help information.
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A simple Mac app for symbolicating macOS/iOS crash reports.
 Supports symbolicating:
 
 - .crash and .ips crash reports
-- sample and spindump reports
+- sample, spindump and hang reports
 
 Includes a command-line interface (`MacSymbolicator.app/Contents/MacOS/MacSymbolicatorCLI`):
 


### PR DESCRIPTION
Some tools export application freezes as `.hang` files containing stack traces for every process on the Mac.

This change does the following:
- Only search for a given dSYM once, even if it appears in multiple processes
- CLI: Add option to only symbolicate process names containing a particular substring
  Avoids attempting to symbolicate everything the mac was running!
- GUI: Allow the drop zone to accept *.hang files