### PR TITLE
Support launching app by opening file

### DIFF
--- a/MacSymbolicator/Controllers/AppDelegate.swift
+++ b/MacSymbolicator/Controllers/AppDelegate.swift
@@ -27,6 +27,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func application(_ sender: NSApplication, openFile filename: String) -> Bool {
-        mainController.openFile(filename)
+		DispatchQueue.main.async {
+			_ = self.mainController.openFile(filename)
+		}
+		return true
     }
 }

--- a/MacSymbolicator/Controllers/MainController.swift
+++ b/MacSymbolicator/Controllers/MainController.swift
@@ -46,6 +46,7 @@ class MainController {
         symbolicateButton.title = "Symbolicate"
         symbolicateButton.bezelStyle = .rounded
         symbolicateButton.focusRingType = .none
+        symbolicateButton.keyEquivalent = "\r"
         symbolicateButton.target = self
         symbolicateButton.action = #selector(MainController.symbolicate)
 


### PR DESCRIPTION
Currently, launching MacSymbolicator by e.g. dragging a file on its icon does open the app, but ignores the file that was dragged. This PR fixes that.

Also, the PR adds support for pressing ⏎ to show the symbolicated result. It's super handy for me but I understand if that doesn't seem like the right choice to you, of course!