### PR TITLE
Convert HTML entities for < and > back to actual characters

### DIFF
--- a/MacSymbolicator/Models/ReportFile.swift
+++ b/MacSymbolicator/Models/ReportFile.swift
@@ -47,6 +47,10 @@ public class ReportFile {
         do {
             originalContent = try String(contentsOf: path, encoding: .utf8)
                 .trimmingCharacters(in: .whitespacesAndNewlines)
+                // Copying and pasting from Help Scout, and possibly other web based systems,
+                // leaves unconverted &lt; and &gt; in the content
+                .replacingOccurrences(of: "&lt;", with: "<")
+                .replacingOccurrences(of: "&gt;", with: ">")
         } catch {
             throw InitializationError.readingFile(error)
         }


### PR DESCRIPTION
When crash log data is copied directly from the 'Show Original' interface of Help Scout, the `<` and `>` characters are encoded as `&lt;` and `&gt;`, causing the parser to fail to find binary images. Convert any such encoded characters back before attempting a scan.

I realize this is kind of a special case for a very particular workflow, but if it doesn't bother you much to include it, I think it only makes the parser more resilient to funny input.