### PR TITLE
Quiet a console warning from the system

### DIFF
--- a/MacSymbolicator/Controllers/AppDelegate.swift
+++ b/MacSymbolicator/Controllers/AppDelegate.swift
@@ -32,4 +32,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 		}
 		return true
     }
+
+	func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
+		return true
+	}
+	
 }


### PR DESCRIPTION
Quiet a console warning from the system about not opting in to applicationSupportsSecureRestorableState. I think because the app doesn't do anything special to customize state restoration, it's safe to do this.