### PR TITLE
Fix Binary Images regex to avoid scanning entire document

### DIFF
--- a/MacSymbolicator/Models/BinaryImage.swift
+++ b/MacSymbolicator/Models/BinaryImage.swift
@@ -10,7 +10,7 @@ struct BinaryImage: Equatable, Hashable {
     let uuid: BinaryUUID
     let loadAddress: String
 
-    private static let binaryImagesSectionRegex = #"Binary Images:.*"#
+    private static let binaryImagesSectionRegex = #"Binary Images:.*?(?=\n\s*\n|\Z)"#
     private static let binaryImagesLineRegex = #"(0x.*?)\s.*?<(.*?)>.*/(.+)$"#
 
     static func find(in content: String) -> [BinaryImage] {


### PR DESCRIPTION
## Problem
Opening the sample file becomes significantly slow when the `Full Report` section is large.

## Root Cause
The regular expression used to parse the **Binary Images** section is greedy, causing excessive backtracking and poor performance when processing large `Full Report` blocks.

## Fix
Replaced the greedy regex with a non-greedy variant to improve the efficiency of parsing the **Binary Images** section. This change reduces unnecessary processing and improves file loading time, especially for large reports.